### PR TITLE
Change 'operation' to 'method'

### DIFF
--- a/design-notes/ces-compared.md
+++ b/design-notes/ces-compared.md
@@ -123,9 +123,9 @@ CE uses `let! x = xs in  ... ` for the binding.
 For those familiar with Haskell, it is natural to think of this as offering a syntax for `Monad`
 instances.  Here’s how the Haskell terminology maps across:
 
--	the Monad _bind_ (`>>=`) operation corresponds to the `let!` syntax mapping to the `Bind` method
+-	the Monad _bind_ (`>>=`) method corresponds to the `let!` syntax mapping to the `Bind` method
 
--	the Monad `return` operation corresponds to `return x` syntax mapping to the `Return` method
+-	the Monad `return` method corresponds to `return x` syntax mapping to the `Return` method
 
 This allows code like this:
 
@@ -170,13 +170,13 @@ Note you have a `For` method.  The presence of the `For` method means `for x in 
 
 For those familiar with Haskell, it is natural to think of this as offering a syntax for things that in Haskell logically correspond to [`MonadPlus`](https://wiki.haskell.org/MonadPlus) instances.  Here’s how the Haskell terminology maps across:
 
-- In F#, the Haskell MonadPlus _bind_ (`>>=`) operation corresponds to the `for` syntax and is de-sugared to the `For` method
+- In F#, the Haskell MonadPlus _bind_ (`>>=`) method corresponds to the `for` syntax and is de-sugared to the `For` method
 
-- The MonadPlus `mplus` operation corresponds to sequential composition `e1; e2` syntax (perhaps on two aligned lines with no semicolon), and is de-sugared to the `Combine` method
+- The MonadPlus `mplus` method corresponds to sequential composition `e1; e2` syntax (perhaps on two aligned lines with no semicolon), and is de-sugared to the `Combine` method
 
-- The MonadPlus `return` operation corresponds to `yield` syntax and is de-sugared to the `Yield` method
+- The MonadPlus `return` method corresponds to `yield` syntax and is de-sugared to the `Yield` method
 
-- The MonadPlus `mzero` operation is inserted implicitly by the compiler (eg. on the empty else branch of an if/then) and is de-sugared to the `Zero` method
+- The MonadPlus `mzero` method is inserted implicitly by the compiler (eg. on the empty else branch of an if/then) and is de-sugared to the `Zero` method
 
 This allows source syntax like this to be de-sugared:
 


### PR DESCRIPTION
Last edit, I think 😄 

---

In Haskell, the term _operation_ isn't that commonly used, but (perhaps surprisingly) functions that are part of a type class definition are often called _methods_. Haskell programmers who don't call them _methods_ are (IME) more likely to call them _functions_ than _operations_.

The term _operation_ seems reminiscent of the word _action_, which in Haskell is mostly used to discuss side-effectful behaviour.