### PR TITLE
Update on-teaching-operators.md

### DIFF
--- a/design-notes/on-teaching-operators.md
+++ b/design-notes/on-teaching-operators.md
@@ -73,7 +73,7 @@ These operators are found in F# code but can normally be left off a teaching pat
 with a simple google search:
 
     %                                Modulus
-    &&& ||| ^^^                      Bitwise (&& in C#)
+    &&& ||| ^^^                      Logical (&& in C#)
     <<< >>>                          Bitwise shift (<< in C#)
     ~~~                              Bitwise negation (~ in C#)
 

--- a/design-notes/on-teaching-operators.md
+++ b/design-notes/on-teaching-operators.md
@@ -73,7 +73,7 @@ These operators are found in F# code but can normally be left off a teaching pat
 with a simple google search:
 
     %                                Modulus
-    &&& ||| ^^^                      Logical (&& in C#)
+    &&& ||| ^^^                      Bitwise (&, |, ^ in C#)
     <<< >>>                          Bitwise shift (<< in C#)
     ~~~                              Bitwise negation (~ in C#)
 


### PR DESCRIPTION
bitwise operators in C# is & instead of &&. I think you mean logical operators.